### PR TITLE
Update search URL

### DIFF
--- a/addic7ed_cli/episode.py
+++ b/addic7ed_cli/episode.py
@@ -106,10 +106,10 @@ class Episode(object):
 
 
 def search(query):
-    results = session.get('/srch.php',
+    results = session.get('/search.php',
                           params={'search': query, 'Submit': 'Search'})
     last_url = session.last_url
-    if '/srch.php' in last_url:
+    if '/search.php' in last_url:
         return [
             Episode(quote(encode(link.attrib['href'])),
                     encode(link.text))


### PR DESCRIPTION
Since 2 days, search results are always empty.

It looks like search URL has changed.

KO: http://www.addic7ed.com/srch.php?search=The+Handmaid%27s+Tale.S02E04
OK: http://www.addic7ed.com/search.php?search=The+Handmaid%27s+Tale.S02E04